### PR TITLE
Update api url to viafintech.com

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 PATH
   remote: .
   specs:
-    barzahlen (2.0.0)
+    barzahlen (2.1.0)
       grac (~> 2.2.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    ethon (0.8.1)
+    ethon (0.12.0)
       ffi (>= 1.3.0)
-    ffi (1.9.25)
-    grac (2.2.1)
+    ffi (1.14.2)
+    grac (2.2.2)
       typhoeus (~> 0.6.9)
     rack (2.2.3)
     rack-test (0.6.3)

--- a/README.md
+++ b/README.md
@@ -421,16 +421,16 @@ For bugs and feature requests open an issue on Github. For code contributions fo
 
 [LICENSE](LICENSE) (MIT)
 
-[control_center_app]: https://controlcenter.barzahlen.de
-[api_documentation_base]: http://docs.barzahlen.de/api/v2
-[api_documentation_idempotency]: http://docs.barzahlen.de/api/v2#idempotency
-[api_documentation_signature]: http://docs.barzahlen.de/api/v2#calculating-the-signature
-[api_documentation_webhooks]: http://docs.barzahlen.de/api/v2#webhooks
-[api_documentation_rate_limit]: http://docs.barzahlen.de/api/v2#rate-limiting
-[api_documentation_sandbox]: http://docs.barzahlen.de/api/v2#sandbox
-[api_documentation_slip]: http://docs.barzahlen.de/api/v2#create-slip
-[api_documentation_retrieve]: http://docs.barzahlen.de/api/v2#retrieve-slip
-[api_documentation_update]: http://docs.barzahlen.de/api/v2#update-slip
-[api_documentation_resend]: http://docs.barzahlen.de/api/v2#resend-email-text-message
-[api_documentation_invalidate]: http://docs.barzahlen.de/api/v2#invalidate-slip
-[api_documentation_error]: http://docs.barzahlen.de/api/v2#errors
+[control_center_app]: https://controlcenter.viacash.com
+[api_documentation_base]: http://docs.viafintech.com/api/v2
+[api_documentation_idempotency]: http://docs.viafintech.com/api/v2#idempotency
+[api_documentation_signature]: http://docs.viafintech.com/api/v2#calculating-the-signature
+[api_documentation_webhooks]: http://docs.viafintech.com/api/v2#webhooks
+[api_documentation_rate_limit]: http://docs.viafintech.com/api/v2#rate-limiting
+[api_documentation_sandbox]: http://docs.viafintech.com/api/v2#sandbox
+[api_documentation_slip]: http://docs.viafintech.com/api/v2#create-slip
+[api_documentation_retrieve]: http://docs.viafintech.com/api/v2#retrieve-slip
+[api_documentation_update]: http://docs.viafintech.com/api/v2#update-slip
+[api_documentation_resend]: http://docs.viafintech.com/api/v2#resend-email-text-message
+[api_documentation_invalidate]: http://docs.viafintech.com/api/v2#invalidate-slip
+[api_documentation_error]: http://docs.viafintech.com/api/v2#errors

--- a/lib/barzahlen/configuration.rb
+++ b/lib/barzahlen/configuration.rb
@@ -1,7 +1,7 @@
 module Barzahlen
   class Configuration
-    API_HOST = "https://api.barzahlen.de/v2"
-    API_HOST_SANDBOX = "https://api-sandbox.barzahlen.de/v2"
+    API_HOST = "https://api.viafintech.com/v2"
+    API_HOST_SANDBOX = "https://api-sandbox.viafintech.com/v2"
 
     attr_accessor :sandbox
     attr_accessor :division_id

--- a/lib/barzahlen/version.rb
+++ b/lib/barzahlen/version.rb
@@ -1,3 +1,3 @@
 module Barzahlen
-  VERSION = "2.0.0"
+  VERSION = '2.1.0'
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -10,8 +10,8 @@ module Barzahlen
     end
 
     it "has valid constant values" do
-      expect(Barzahlen::Configuration::API_HOST).to eq("https://api.barzahlen.de/v2")
-      expect(Barzahlen::Configuration::API_HOST_SANDBOX).to eq("https://api-sandbox.barzahlen.de/v2")
+      expect(Barzahlen::Configuration::API_HOST).to eq("https://api.viafintech.com/v2")
+      expect(Barzahlen::Configuration::API_HOST_SANDBOX).to eq("https://api-sandbox.viafintech.com/v2")
     end
 
     it "can set specific values" do

--- a/spec/lib/error_spec.rb
+++ b/spec/lib/error_spec.rb
@@ -33,7 +33,7 @@ module Barzahlen
           error_class: "invalid_parameter",
           error_code: "reference_key_already_exists",
           message: "The given reference key already exists - use another one.",
-          documentation_url: "https://www.barzahlen.de/",
+          documentation_url: "https://www.viafintech.com/",
           request_id: "64ec26b27d414a66b87f2ec7cad7e92c"
         }
       }
@@ -120,7 +120,7 @@ module Barzahlen
         expect(error_class.error_class).to eq("invalid_parameter")
         expect(error_class.error_code).to eq("reference_key_already_exists")
         expect(error_class.error_message).to eq("The given reference key already exists - use another one.")
-        expect(error_class.documentation_url).to eq("https://www.barzahlen.de/")
+        expect(error_class.documentation_url).to eq("https://www.viafintech.com/")
         expect(error_class.request_id).to eq("64ec26b27d414a66b87f2ec7cad7e92c")
       end
 
@@ -139,7 +139,7 @@ module Barzahlen
         error_body = "502 Bad Gateway"
         error_class = Barzahlen::Error.generate_error_from_response(error_body)
 
-        expect(error_class.message).to eq("Error occurred with: Please contact CPS to help us fix that as soon as possible.")
+        expect(error_class.message).to eq("Error occurred with: Please contact viafintech to help us fix that as soon as possible.")
       end
     end
   end

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -11,7 +11,7 @@ module Barzahlen
         end
 
         @date = "13 Apr 2016 15:00:00 GMT"
-        @request_uri = "https://api.barzahlen.de/v2"
+        @request_uri = "https://api.viafintech.com/v2"
         @request_method = "get"
 
         @idempotency_key = "6729eb3c-e4b7-49ef-adb6-cbbfdb327774"
@@ -52,8 +52,8 @@ module Barzahlen
           {
             headers: {
               Date: @date,
-              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=54295c2524a83e8067510a8b49c14089158162f47b202d5e6be57ee81b810542",
-              Host: "api.barzahlen.de:443"
+              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=5daa2167ae9a510fbc144ca246ab42d18695b2903de238ccc72f2552f888037b",
+              Host: "api.viafintech.com:443"
             }
           },
           @request_uri,
@@ -81,8 +81,8 @@ module Barzahlen
           {
             headers: {
               Date: @date,
-              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=0b3b29ee6f126ffc01f6ab279e8d92119ce4ca758125db86777d20683bdec63e",
-              Host: "api.barzahlen.de:443",
+              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=c07c626d221b73cd8f3d7e125e4f74421c19016f352f0845b0a64068a2d9392c",
+              Host: "api.viafintech.com:443",
               "Idempotency-Key" => @idempotency_key
             }
           },
@@ -113,8 +113,8 @@ module Barzahlen
           {
             headers: {
               Date: @date,
-              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=2688e8ddea8c85591239f45248463f04b1013783063cb20851e65e5513f3e602",
-              Host: "api.barzahlen.de:443",
+              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=0aa39eb2eaf092547bcae9da3a0d506c2ac5cc119441b28d9303af43d3f65ebd",
+              Host: "api.viafintech.com:443",
             }
           },
           @request_uri,
@@ -140,8 +140,8 @@ module Barzahlen
           {
             headers: {
               Date: @date,
-              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=5e5c482d13c9f298e39496273a6f2d56325a7d99727486b49ac9532fe72d62ed",
-              Host: "api.barzahlen.de:443",
+              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=3eb8454ced6bd75f3ac7c136737f73ba540f8f5ebc652ec1ffcba7109ed8085e",
+              Host: "api.viafintech.com:443",
             }
           },
           @request_uri,
@@ -167,8 +167,8 @@ module Barzahlen
           {
             headers: {
               Date: @date,
-              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=66cd7fe64fbd25dc56aacf59055b363f9b41342dfb44f8348226ca9516bbd466",
-              Host: "api.barzahlen.de:443",
+              Authorization: "BZ1-HMAC-SHA256 DivisionId=12345, Signature=61ce6f17bdb8a2a1dbb3b1c96103b861820c91a9a1716a4ddab206d23f4c5849",
+              Host: "api.viafintech.com:443",
             }
           },
           @request_uri,
@@ -189,7 +189,7 @@ module Barzahlen
           config.payment_key = "123456"
         end
 
-        @request_host_header = "api.barzahlen.de"
+        @request_host_header = "api.viafintech.com"
         @request_method = "GET"
         @request_date_header = "13 Apr 2016 15:00:00 GMT"
         @request_host_path = ""
@@ -206,7 +206,7 @@ module Barzahlen
           @request_date_header
           )
 
-        expect(signature).to eq("f9657db3b4adba7c838a16f22a7e3202c80d5f09c2a8caae7f065d0015b6c0b1")
+        expect(signature).to eq("7e5f2c381a959e7fc41494336e49540847df0bba9839684346c83c4ffa54b5fb")
       end
 
       it "generates the signature correctly with idempotency key" do
@@ -221,7 +221,7 @@ module Barzahlen
           @request_idempotency_key
           )
 
-        expect(signature).to eq("6152ebdf8ba4254bf069c63c7e84d48a8f85606821a17637ecf838114a7b3159")
+        expect(signature).to eq("6f01064910997e08435e23e929b252218e5eb359dfbfd7ac20ad740d7ef62630")
       end
 
       it "generates the signature correctly everything set" do
@@ -240,7 +240,7 @@ module Barzahlen
           @request_idempotency_key
           )
 
-        expect(signature).to eq("35235b5aa4a7a0e30aa6ca9fe115cfff2f8b100ddca0eaf8370f2c557305a1f8")
+        expect(signature).to eq("86dc61c90021e03387e0daeb19004503da6440a0c45376c402f2b3d4a40ac678")
       end
 
       it "generates a correct webhook signature" do
@@ -304,7 +304,7 @@ module Barzahlen
           config.payment_key = "6b3fb3abef828c7d10b5a905a49c988105621395"
         end
 
-        @request_host_header = "api.barzahlen.de"
+        @request_host_header = "api.viafintech.com"
         @request_method = "GET"
         @request_date_header = "Thu, 31 Mar 2016 10:50:31 GMT"
         @request_host_path = "/v2/slips/slp-d90ab05c-69f2-4e87-9972-97b3275a0ccd"
@@ -323,7 +323,7 @@ module Barzahlen
           @request_idempotency_key
           )
 
-        expect(signature).to eq("3b1a28fffd1cd2bbc1ec24cfbca1e85d802159e78c08328d92d4337a4a33b61d")
+        expect(signature).to eq("d79eec400bdc4506a65291382f460af262ab5b0d8641445e6b28c3fba9f7e4c1")
       end
     end
   end

--- a/spec/lib/slip_spec.rb
+++ b/spec/lib/slip_spec.rb
@@ -58,7 +58,7 @@ module Barzahlen
     it "is setting correct uri" do
       Barzahlen::CreateSlipRequest.new(refund_slip)
 
-      expect(@@grac_client.uri).to eq("https://api.barzahlen.de/v2")
+      expect(@@grac_client.uri).to eq("https://api.viafintech.com/v2")
     end
 
     it "is setting correct sandbox uri" do
@@ -68,7 +68,7 @@ module Barzahlen
 
       Barzahlen::CreateSlipRequest.new(refund_slip)
 
-      expect(@@grac_client.uri).to eq("https://api-sandbox.barzahlen.de/v2")
+      expect(@@grac_client.uri).to eq("https://api-sandbox.viafintech.com/v2")
     end
 
     it "generates a payment and creates request with grac" do


### PR DESCRIPTION
The API is now reachable through api.viafintech.com/api-sandbox.viafintech.com in the process of our rebranding.

This updates the client library to also use the new URL accordingly